### PR TITLE
Add plant detail page with sensor actions and hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "jwt-decode": "^4.0.0",
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "swr": "^2.3.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2580,6 +2581,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -5917,6 +5927,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
@@ -6241,6 +6264,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "jwt-decode": "^4.0.0",
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "swr": "^2.3.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -1,33 +1,31 @@
 // 📁 src/components/PlantCard.jsx
 import { useRouter } from "next/router";
-import SensorBar      from "./SensorBar";
-
-// mapping couleur + label par status
-const badgeMap = {
-  OK:       ["bg-green-600", "Excellent"],
-  LOW:      ["bg-yellow-400", "Attention"],
-  CRITICAL: ["bg-red-500",   "Alerte"],
-};
+import SensorBar from "./SensorBar";
 
 export default function PlantCard({ plant }) {
   const router = useRouter();
 
-  // 🔑 1) Dernière mesure par type
+  /* 1. Dernière mesure par type */
   const latestByType = {};
   (plant.sensors || []).forEach((s) => {
-    const key = s.type;
-    // garde la plus récente
-    if (!latestByType[key] || new Date(s.timestamp) > new Date(latestByType[key].timestamp)) {
-      latestByType[key] = s;
+    if (!latestByType[s.type] || new Date(s.timestamp) > new Date(latestByType[s.type].timestamp)) {
+      latestByType[s.type] = s;
     }
   });
 
-  // 🔑 2) Capteur pivot (défini en DB ou fallback moist)
-  const pivot = plant.main_sensor || "soil_moisture";
-  const pivotStatus = latestByType[pivot]?.status || "OK";
-  const [badgeColor, badgeText] = badgeMap[pivotStatus] ?? badgeMap.OK;
+  /* 2. Capteur pivot & badge */
+  const mainSensorType = plant.main_sensor || "soil_moisture";
+  const mainSensor     = (plant.sensors || []).find(s => s.type === mainSensorType);
 
-  // 🔑 3) Valeurs pour barres
+  const badgeColor =
+    mainSensor?.status === "OK"        ? "bg-green-500"
+    : mainSensor?.status === "LOW"     ? "bg-yellow-400"
+    : mainSensor?.status === "CRITICAL"? "bg-red-500"
+    : "bg-gray-300";
+
+  const badgeText = mainSensor?.status || "—";
+
+  /* 3. Valeurs pour barres */
   const latest = {
     soil:     latestByType.soil_moisture?.value,
     temp:     latestByType.temperature?.value,
@@ -38,9 +36,9 @@ export default function PlantCard({ plant }) {
   return (
     <div
       onClick={() => router.push(`/dashboard/${plant.plant_id}`)}
-      className="cursor-pointer bg-white rounded-2xl shadow hover:shadow-lg transition p-5 flex flex-col sm:flex-row justify-between"
+      className="cursor-pointer bg-white rounded-2xl shadow hover:shadow-lg transition p-5 flex flex-col"
     >
-      {/* LEFT */}
+      {/* HEADER */}
       <div className="flex flex-col gap-1">
         <h2 className="text-lg font-bold">{plant.plant_name}</h2>
         <p className="text-sm text-gray-500">{plant.plant_type}</p>
@@ -49,20 +47,17 @@ export default function PlantCard({ plant }) {
         </span>
       </div>
 
-      {/* MIDDLE – 4 capteurs */}
-      <div className="flex-1 grid grid-cols-2 md:grid-cols-4 gap-6 items-center mt-4 sm:mt-0">
+      {/* CAPTEURS */}
+      <div className="flex-1 grid grid-cols-2 md:grid-cols-4 gap-6 items-center mt-4">
         <SensorBar icon="🌱" label="Moisture" value={latest.soil}      barColor="blue"   />
         <SensorBar icon="💡" label="Light"    value={latest.light}     barColor="amber"  unit="lx" />
         <SensorBar icon="🌡️" label="Temp"     value={latest.temp}      barColor="orange" unit="°C" />
         <SensorBar icon="💧" label="Humidity" value={latest.humidity}  barColor="pink"   />
       </div>
 
-      {/* RIGHT */}
-      <div className="text-xs text-gray-500 mt-4 sm:mt-0 sm:text-right">
-        Last watered:{" "}
-        {plant.lastActionAt
-          ? new Date(plant.lastActionAt).toLocaleString()
-          : "—"}
+      {/* FOOTER */}
+      <div className="text-xs text-gray-500 mt-4 sm:text-right">
+        Last watered: {plant.lastActionAt ? new Date(plant.lastActionAt).toLocaleString() : "—"}
       </div>
     </div>
   );

--- a/src/components/SensorCard.jsx
+++ b/src/components/SensorCard.jsx
@@ -1,0 +1,32 @@
+// 📁 components/SensorCard.jsx
+export default function SensorCard({ type, value, status, onAction, isManual }) {
+  const sensorInfo = {
+    temperature: { label: "Temperature", icon: "🌡️", unit: "°C", action: "Adjust Temp" },
+    humidity: { label: "Humidity", icon: "💧", unit: "%", action: "Humidify" },
+    soil_moisture: { label: "Moisture", icon: "🌱", unit: "%", action: "Water Plant" },
+    light: { label: "Light", icon: "💡", unit: "lx", action: "Add Light" }
+  };
+
+  const { label, icon, unit, action } = sensorInfo[type] || {};
+  const alertColor = status === "CRITICAL" ? "bg-red-600" :
+                     status === "LOW" ? "bg-yellow-400" : "bg-green-500";
+
+  return (
+    <div className={`rounded-lg p-4 shadow-md text-center ${alertColor} text-white`}>
+      <div className="text-3xl">{icon}</div>
+      <div className="text-lg font-semibold">{label}</div>
+      <div className="text-xl">{value}{unit}</div>
+      {status !== "OK" && (
+        <div className="text-sm italic">{status === "LOW" ? "Needs attention" : "Critical condition"}</div>
+      )}
+      {isManual && (
+        <button
+          onClick={onAction}
+          className="mt-2 bg-white text-black px-3 py-1 rounded hover:bg-gray-200 transition"
+        >
+          {action}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/usePlantDetail.js
+++ b/src/hooks/usePlantDetail.js
@@ -1,0 +1,26 @@
+import useSWR from "swr";
+import { getPlantDetail }  from "../lib/plantService";
+import { getLatestActions } from "../lib/actionService";
+
+export const usePlantDetail = (id) => {
+  const { data: plantData, error: plantError, mutate } = useSWR(
+    id ? ["plant", id] : null,
+    () => getPlantDetail(id),
+    { refreshInterval: 30_000 }
+  );
+
+  const { data: actions } = useSWR(
+    id ? ["actions", id] : null,
+    () => getLatestActions(id),
+    { refreshInterval: 30_000 }
+  );
+
+  return {
+    plant: plantData,                // ✅ ici : c'est l’objet complet
+    sensors: plantData?.sensors ?? [],
+    actions,
+    loading: !plantData && !plantError,
+    error: plantError,
+    mutate,
+  };
+};

--- a/src/lib/actionService.js
+++ b/src/lib/actionService.js
@@ -1,0 +1,10 @@
+// 📁 src/lib/actionService.js
+import axios from "./axios";   // baseURL = "http://localhost:5000/api"
+
+export const getLatestActions = (id) =>
+  axios.get(`/actions/${id}/latest`).then(r => r.data.actions);
+
+// bonne URL : /api + /simulate/plants/:id/apply-action
+export const applyAction = (id, payload) =>
+  axios.post(`/simulate/plants/${id}/apply-action`, payload)
+       .then(r => r.data);

--- a/src/lib/plantService.js
+++ b/src/lib/plantService.js
@@ -3,3 +3,8 @@ import axios from './axios';
 // get all plant of a user
 export const getPlants = () =>
   axios.get("/plants/all").then((r) => r.data.plants); 
+
+// indos complete plant + sensors + pivot + auto
+export const getPlantDetail = (id) =>
+  axios.get(`/${id}/with-sensors`)
+       .then(res => res.data.data); 

--- a/src/pages/dashboard/[plantId]/index.jsx
+++ b/src/pages/dashboard/[plantId]/index.jsx
@@ -1,0 +1,129 @@
+// 📁 pages/dashboard/[plantId]/index.jsx
+import { useRouter } from "next/router";
+import { usePlantDetail } from "@/hooks/usePlantDetail";
+import { applyAction } from "@/lib/actionService";
+import SensorBar from "@/components/SensorBar";
+
+export default function PlantDetail() {
+  const { plantId } = useRouter().query;
+  const { plant, sensors, actions, loading, error, mutate } = usePlantDetail(plantId);
+
+  if (loading) return <p className="p-4">Chargement…</p>;
+  if (error) return <p className="p-4 text-red-500">Erreur : {error.message}</p>;
+
+  const mainSensorType = plant.main_sensor || "soil_moisture";
+  const mainSensor = (sensors || []).find(s => s.type === mainSensorType);
+  const badgeColor =
+    mainSensor?.status === "OK"        ? "bg-green-500"
+    : mainSensor?.status === "LOW"     ? "bg-yellow-400"
+    : mainSensor?.status === "CRITICAL"? "bg-red-500"
+    : "bg-gray-300";
+
+  const latestByType = {};
+  (sensors || []).forEach((s) => {
+    if (!latestByType[s.type] || new Date(s.timestamp) > new Date(latestByType[s.type].timestamp)) {
+      latestByType[s.type] = s;
+    }
+  });
+
+  const handleAction = async (sensor_type) => {
+    await applyAction(plantId, { sensor_type });
+    mutate(); // refresh everything
+  };
+
+  return (
+    <div className="p-6 space-y-6 max-w-4xl mx-auto">
+      {/* 🔹 Title + description + image */}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold text-gray-800">{plant.plant_name}</h1>
+        <p className="text-sm text-gray-500">{plant.plant_type}</p>
+        <p className="text-gray-600">{plant.description}</p>
+        {plant.image_url && (
+          <img
+            src={plant.image_url}
+            alt={plant.plant_name}
+            className="w-full max-h-[400px] object-cover rounded-xl shadow"
+          />
+        )}
+      </div>
+
+      {/* 🔸 Sensor + Actions Card */}
+      <div className="p-6 space-y-6 bg-white rounded-xl shadow">
+        {/* Status & mode */}
+        <div className="flex items-center justify-between">
+          <span className={`text-xs text-white px-2 py-0.5 rounded ${badgeColor}`}>
+            {mainSensor?.status || "—"}
+          </span>
+          <span className={`text-xs px-2 py-0.5 rounded 
+            ${plant.is_automatic ? "bg-blue-100 text-blue-600" : "bg-gray-100 text-gray-600"}`}>
+            {plant.is_automatic ? "AUTO" : "MANUAL"}
+          </span>
+        </div>
+
+        {/* Sensor bar grid */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 items-center">
+          <SensorBar
+            icon="🌱"
+            label="Moisture"
+            value={latestByType.soil_moisture?.value}
+            barColor="blue"
+            unit="%"
+          />
+          <SensorBar
+            icon="💡"
+            label="Light"
+            value={latestByType.light?.value}
+            barColor="amber"
+            unit="lx"
+          />
+          <SensorBar
+            icon="🌡️"
+            label="Temp"
+            value={latestByType.temperature?.value}
+            barColor="orange"
+            unit="°C"
+          />
+          <SensorBar
+            icon="💧"
+            label="Humidity"
+            value={latestByType.humidity?.value}
+            barColor="pink"
+            unit="%"
+          />
+        </div>
+
+        {/* Last watered */}
+        <div className="text-xs text-right text-gray-500">
+          Last watered: {plant.lastActionAt ? new Date(plant.lastActionAt).toLocaleString() : "—"}
+        </div>
+
+        {/* Manual Actions */}
+        {!plant.is_automatic && (
+  <div className="mt-4">
+    <button
+      className="bg-red-500 hover:bg-red-600 text-white font-semibold w-full py-3 rounded-lg shadow">
+      🚨 Launch Action
+    </button>
+    <p className="text-xs text-gray-400 text-center mt-1">Based on latest critical sensor</p>
+  </div>
+)}
+
+        {/* Actions Log */}
+        <div className="mt-6">
+            <h2 className="text-lg font-semibold mb-2">Dernières actions</h2>
+            {actions?.length ? (
+                <ul className="space-y-1 text-sm text-gray-700">
+                {actions.slice(0, 2).map((a) => (
+                    <li key={a._id}>
+                    {new Date(a.timestamp).toLocaleString()} — {a.action}
+                    </li>
+                ))}
+                </ul>
+            ) : (
+                <p className="text-sm text-gray-500">Aucune action enregistrée.</p>
+            )}
+            </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduces a detailed plant dashboard page at /dashboard/[plantId] with sensor status, manual actions, and action logs. Adds usePlantDetail hook for fetching plant and action data, actionService for API calls, and updates PlantCard for improved badge logic. Also adds SWR dependency for data fetching.