### PR TITLE
Update default API base URL to localhost

### DIFF
--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -2,7 +2,7 @@
 import axios from "axios";
 
 const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "https://f35aac998111.ngrok-free.app/api",
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api",
   withCredentials: false,
 });
 


### PR DESCRIPTION
Changed the fallback baseURL in axios instance from a remote ngrok address to http://localhost:5000/api for local development.