### PR TITLE
Remove localhost fallback from API base URL

### DIFF
--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -1,7 +1,7 @@
 // src/lib/axios.js
 import axios from "axios";
 
-const raw = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000/api";
+const raw = process.env.NEXT_PUBLIC_API_BASE_URL;
 const base = raw.replace(/\/+$/, "");
 const apiBase = base.endsWith("/api") ? base : `${base}/api`;
 


### PR DESCRIPTION
The API base URL now strictly uses the NEXT_PUBLIC_API_BASE_URL environment variable and no longer defaults to 'http://localhost:5000/api'. This change enforces explicit configuration of the API endpoint.