### PR TITLE
Update color palette to use custom green and red shades

### DIFF
--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -129,10 +129,10 @@ export default function NotificationBell() {
                   let Icon = FaFileAlt;
                   let iconColor = "text-gray-500 bg-gray-200";
                   switch (notif.type) {
-                    case "delete": Icon = FaTrash; iconColor = "text-red-600 bg-red-200"; break;
+                    case "delete": Icon = FaTrash; iconColor = "text-[#de3d31] bg-red-200"; break;
                     case "article": Icon = FaFileAlt; iconColor = "text-blue-600 bg-blue-200"; break;
                     case "plant":
-                    case "add_plant": Icon = FaSeedling; iconColor = "text-green-600 bg-green-200"; break;
+                    case "add_plant": Icon = FaSeedling; iconColor = "text-[#09552b] bg-[#8eb49f]"; break;
                     case "alert": Icon = FaExclamationCircle; iconColor = "text-yellow-600 bg-yellow-200"; break;
                   }
                   return (

--- a/src/components/ProfileHeader.jsx
+++ b/src/components/ProfileHeader.jsx
@@ -32,7 +32,7 @@ export default function ProfileHeader({ title = "Profil" }) {
       {/* Logout icon */}
       <button
         onClick={handleLogout}
-        className="text-gray-600 hover:text-red-600 text-2xl"
+        className="text-gray-600 hover:text-[#de3d31] text-2xl"
         aria-label="Déconnexion"
       >
         <FaSignOutAlt />

--- a/src/components/SensorCard.jsx
+++ b/src/components/SensorCard.jsx
@@ -13,7 +13,7 @@ export default function SensorCard({ type, value, status, onAction, isManual }) 
   };
 
   const { label, icon: IconComponent, unit, action, barColor } = sensorInfo[type] || {};
-  const alertColor = status === "CRITICAL" ? "bg-red-600" :
+  const alertColor = status === "CRITICAL" ? "bg-[#de3d31]" :
                      status === "LOW" ? "bg-yellow-400" : "bg-green-500";
 
   // Convert value for percentage display (light sensor needs different scaling)
@@ -58,7 +58,7 @@ export default function SensorCard({ type, value, status, onAction, isManual }) 
           onClick={onAction}
           className={`mt-3 px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200 w-full ${
             status === "CRITICAL" 
-              ? "bg-red-500 hover:bg-red-600 text-white shadow-lg hover:shadow-xl" 
+              ? "bg-red-500 hover:bg-[#de3d31] text-white shadow-lg hover:shadow-xl" 
               : "bg-yellow-500 hover:bg-yellow-600 text-white shadow-md hover:shadow-lg"
           }`}
         >

--- a/src/components/TabsNav.jsx
+++ b/src/components/TabsNav.jsx
@@ -27,7 +27,7 @@ export default function TabsNav({ activeTab, onTabChange }) {
             className={`flex items-center gap-2 text-sm font-medium pb-2 border-b-2 transition duration-150 ease-in-out ${
               activeTab === key
                 ? 'text-green-700 border-green-700'
-                : 'text-gray-500 border-transparent hover:text-green-600'
+                : 'text-gray-500 border-transparent hover:text-[#09552b]'
             }`}
           >
             {icon}

--- a/src/components/TabsNavPlant.jsx
+++ b/src/components/TabsNavPlant.jsx
@@ -23,7 +23,7 @@ export default function TabsNav({ activeTab, onTabChange }) {
             className={`flex items-center gap-2 text-sm font-medium pb-2 border-b-2 transition duration-150 ease-in-out ${
               activeTab === key
                 ? 'text-green-700 border-green-700'
-                : 'text-gray-500 border-transparent hover:text-green-600'
+                : 'text-gray-500 border-transparent hover:text-[#09552b]'
             }`}
           >
             {icon}

--- a/src/components/UserProfile/LogOut.jsx
+++ b/src/components/UserProfile/LogOut.jsx
@@ -26,7 +26,7 @@ export default function LogOut() {
       <button
         onClick={handleLogout}
         disabled={loading}
-        className="w-full bg-red-600 hover:bg-red-700 text-white font-medium py-3 px-4 rounded-lg flex items-center justify-center gap-2 transition-colors disabled:opacity-50"
+        className="w-full bg-[#de3d31] hover:bg-red-700 text-white font-medium py-3 px-4 rounded-lg flex items-center justify-center gap-2 transition-colors disabled:opacity-50"
       >
         <BiLogOut className="text-xl" />
         {loading ? "Déconnexion..." : "Se déconnecter"}

--- a/src/components/UserProfile/UserInfo.jsx
+++ b/src/components/UserProfile/UserInfo.jsx
@@ -48,7 +48,7 @@ export default function UserInfo({ user: initialUser }) {
       <div className="bg-white rounded-xl shadow p-6 mb-4">
         <div className="text-5xl mb-2 flex flex-col items-center">
           <div className="relative">
-            <ProfilIcon className="text-green-600" />
+            <ProfilIcon className="text-[#09552b]" />
             <div className="absolute -bottom-2 -right-2 bg-[#074221] text-white rounded-full p-1 shadow-lg">
               <GiGardeningShears className="text-xl" />
             </div>

--- a/src/pages/dashboard/[plantId]/index.jsx
+++ b/src/pages/dashboard/[plantId]/index.jsx
@@ -232,7 +232,7 @@ export default function PlantDetail() {
               <div className="absolute right-0 mt-2 w-44 bg-white border rounded-lg shadow-lg z-20">
                 <button
                   onClick={() => setShowDeleteModal(true)}
-                  className="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+                  className="block w-full text-left px-4 py-2 text-sm text-[#de3d31] hover:bg-red-50"
                 >
                   Supprimer la plante
                 </button>
@@ -389,7 +389,7 @@ export default function PlantDetail() {
                 </button>
                 <button
                   onClick={handleDeletePlant}
-                  className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+                  className="px-4 py-2 bg-[#de3d31] text-white rounded-lg hover:bg-red-700"
                   disabled={loadingAction}
                 >
                   {loadingAction ? "Suppression..." : "Supprimer"}

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -43,10 +43,10 @@ export default function Dashboard() {
             <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 px-4 mb-4">
               <div className="p-4 bg-white rounded-lg shadow flex items-center justify-between">
                 <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
-                  <FaSeedling className="text-green-600 text-3xl" />
+                  <FaSeedling className="text-[#09552b] text-3xl" />
                 </div>
                 <div className="text-right">
-                  <p className="text-4xl font-bold text-green-600">{plantCount}</p>
+                  <p className="text-4xl font-bold text-[#09552b]">{plantCount}</p>
                   <p className="text-gray-500">Plantes</p>
                 </div>
               </div>
@@ -82,7 +82,7 @@ export default function Dashboard() {
         
         <Link href="/plant/add" legacyBehavior>
           <a
-            className="fixed bottom-24 right-8 bg-green-600 hover:bg-green-700 text-white rounded-full w-16 h-16 flex items-center justify-center shadow-lg text-3xl z-50 transition-colors duration-200"
+            className="fixed bottom-24 right-8 bg-[#09552b] hover:bg-[#074221] text-white rounded-full w-16 h-16 flex items-center justify-center shadow-lg text-3xl z-50 transition-colors duration-200"
             aria-label="Ajouter une plante"
           >
             +

--- a/src/pages/explore/index.jsx
+++ b/src/pages/explore/index.jsx
@@ -64,7 +64,7 @@ export default function ExplorePage() {
             placeholder="Search articles..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full p-2 pl-10 rounded-full border border-gray-300 focus:outline-none focus:ring-2 focus:ring-green-600 bg-gray-100 text-gray-800"
+            className="w-full p-2 pl-10 rounded-full border border-gray-300 focus:outline-none focus:ring-2 focus:ring-[#09552b] bg-gray-100 text-gray-800"
           />
           
           <svg

--- a/src/pages/plant/add/index.jsx
+++ b/src/pages/plant/add/index.jsx
@@ -358,7 +358,7 @@ export default function AddPlantPage() {
           </form>
         )}
 
-        {error && <p className="text-red-600 text-center">{error}</p>}
+        {error && <p className="text-[#de3d31] text-center">{error}</p>}
 
         {/* Modal résultat (commune aux 2 tabs) */}
         {showResultModal && result && (

--- a/src/pages/plant/health.jsx
+++ b/src/pages/plant/health.jsx
@@ -26,6 +26,8 @@ import Skeleton from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
 import { FaSyncAlt } from "react-icons/fa";
 import { TbHealthRecognition } from "react-icons/tb";
+import { MdVerified } from "react-icons/md";
+import { MdOutlineSick } from "react-icons/md";
 
 const STATIC_BASE = (process.env.NEXT_PUBLIC_STATIC_BASE || "https://awm.portfolio-etudiant-rouen.com/api").replace(/\/+$/, "");
 
@@ -165,7 +167,7 @@ export default function PlantHealthPage() {
 
                   return (
                     <>
-                      <h2 className="text-xl font-bold mb-2 text-red-600">{title}</h2>
+                      <h2 className="text-xl font-bold mb-2 text-[#de3d31]">{title}</h2>
                       <p className="text-sm mb-4 text-gray-700">
                         <strong>Description :</strong>
                         <br />
@@ -211,12 +213,12 @@ export default function PlantHealthPage() {
                     <p className="text-md text-gray-700 mb-1">
                       <strong>Plante en bonne santé :</strong>{" "}
                       {analysisData.result?.health_assessment?.is_healthy ? (
-                        <span className="text-[#0A5D2F] font-semibold">
-                          Aucun signe de maladie détecté
+                        <span className="inline-flex items-center gap-1 text-[#0A5D2F]">
+                          <MdVerified className="text-[#09552b]" /> Aucun signe de maladie détecté
                         </span>
                       ) : (
-                        <span className="text-red-500 font-semibold">
-                          Présence de maladies probables
+                        <span className="inline-flex items-center gap-1 text-red-500">
+                          <MdOutlineSick className="text-[#de3d31]" /> Présence de maladies probables
                         </span>
                       )}
                     </p>
@@ -241,7 +243,7 @@ export default function PlantHealthPage() {
                               </span>
                             </p>
                             <button
-                              className="text-xs text-gray-400 hover:text-green-600 absolute top-2 right-2"
+                              className="text-xs text-gray-400 hover:text-[#09552b] absolute top-2 right-2"
                               onClick={() => {
                                 setShowResultsModal(false);
                                 setSelectedDisease(analysisData.enrichDisease(disease));
@@ -437,7 +439,7 @@ function ScanComponent({ onSelectDisease, onShowResults, setPageLoading }) {
         </button>
       </div>
 
-      {error && <p className="text-red-600 text-center">{error}</p>}
+      {error && <p className="text-[#de3d31] text-center">{error}</p>}
     </div>
   );
 }


### PR DESCRIPTION
Replaces various Tailwind default green and red color classes with custom hex values (#09552b for green, #de3d31 for red) across multiple components and pages for a more consistent and branded UI. Also adds icons for health status in plant health analysis. No logic changes, only style and minor UI improvements.